### PR TITLE
Update KerioConnectClient.download.recipe

### DIFF
--- a/KerioConnectClient/KerioConnectClient.download.recipe
+++ b/KerioConnectClient/KerioConnectClient.download.recipe
@@ -43,7 +43,7 @@
                     <key>input_path</key>
                     <string>%pathname%/Kerio Connect.app</string>
                     <key>requirement</key>
-                    <string>identifier "com.Kerio-Connect" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = ESPPW8V28N</string>
+                    <string>identifier "com.Kerio-Connect" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "ESPPW8V28N"</string>
                 </dict>
             </dict>
             <dict>


### PR DESCRIPTION
Update Team identifier to ESPPW8V28N for new GFI v.10 version of app.